### PR TITLE
EVE-20/Feat: Implement getGroupEvents API

### DIFF
--- a/src/Controllers/group.controller.ts
+++ b/src/Controllers/group.controller.ts
@@ -79,7 +79,32 @@ const getUserGroups = async (req: Request, res: Response) => {
 
 const getGroupById = (req: Request, res: Response) => {};
 
-const getGroupEvent = (req: Request, res: Response) => {};
+const getGroupEvent = async (req: Request, res: Response) => {
+	const groupId = req.params.groupId;
+
+	try {
+		const groupEvents = await prisma.eventGroup.findMany({
+			where: {
+				group_id: groupId,
+			},
+			include: {
+				event: true,
+			},
+		});
+
+		if (groupEvents.length > 0) {
+			res.status(200).json({
+				statusCode: 201,
+				data: groupEvents,
+			});
+		} else {
+			res.status(404).json({ error: 'No events found for this group' });
+		}
+	} catch (error) {
+		console.error(error);
+		res.status(500).json({ error: 'An error occurred while fetching group events.' });
+	}
+};
 
 const addUserToGroup = (req: Request, res: Response) => {};
 

--- a/src/Controllers/group.controller.ts
+++ b/src/Controllers/group.controller.ts
@@ -97,9 +97,14 @@ const getGroupEvent = async (req: Request, res: Response) => {
 		});
 
 		if (groupEvents.length > 0) {
+			const eventObjects = groupEvents.map((groupEvent) => ({
+				...groupEvent.event,
+				group_id: groupEvent.group_id,
+			}));
+
 			res.status(200).json({
 				statusCode: 201,
-				data: groupEvents,
+				data: eventObjects,
 			});
 		} else {
 			res.status(404).json({ error: 'No events found for this group' });

--- a/src/Routes/event.routes.ts
+++ b/src/Routes/event.routes.ts
@@ -16,13 +16,13 @@ const router = Router();
  * This route should take care of creating events should return a 201
  * PROTECTED ROUTE
  */
-router.post('/', upload.single('image'), createEvent);
+router.post('/', upload.single('image'), protect, createEvent);
 
 /*@PUT /events/:id
  * This route should take care of updating events should return a 201
  * PROTECTED ROUTE
  */
-router.put('/:eventId', upload.single('image'), updateEvent);
+router.put('/:eventId', upload.single('image'), protect, updateEvent);
 
 /*@GET /event
  * This route should take care of getting events created by all users

--- a/src/Routes/group.routes.ts
+++ b/src/Routes/group.routes.ts
@@ -10,29 +10,29 @@ import protect from '../middleware/auth.middleware';
 import upload from '../config/multer-cloudinary-config';
 const router = Router();
 
-/*@POST /group
+/*@POST /groups
  * This route should take care of creating groups(no page on the design for this but just use the information in the table)
  */
-router.post('/',upload.single('image'), createGroup);
+router.post('/', upload.single('image'), protect, createGroup);
 
-/*@GET /group
+/*@GET /groups
  * This route should take care of getting all groups user is in
  */
 router.get('/', protect, getUserGroups);
 
-/*@GET /group/info/:groupId
+/*@GET /groups/info/:groupId
  * This route should take care of getting a particular group
  */
 router.get('/info/:groupId', getGroupById);
 
-/*@GET /group/event/:groupId
- * This route should take care of getting all events under groups
+/*@GET /groups/events/:groupId
+ * This route should take care of getting all events under a group
  */
-router.get('/event/:groupId', getGroupEvent);
+router.get('/events/:groupId', getGroupEvent);
 
-/*@POST /groups/:groupId/addUser
+/*@POST /groupss/:groupId/addUser
  * This route should take care of adding a user to a group using the user email address
  */
-router.post('/:groupId/addUser', addUserToGroup);
+router.post('/:groupId/addUser', protect, addUserToGroup);
 
 export default router;

--- a/swagger.ts
+++ b/swagger.ts
@@ -278,6 +278,14 @@ const swaggerDocument = {
 				tags: ['Groups'],
 				summary: 'Add user to group',
 				description: 'This route is used add a user to a group using the user email address.',
+				parameters: [
+					{
+						name: 'groupId',
+						in: 'path',
+						required: true,
+						type: 'string',
+					},
+				],
 				responses: {
 					201: {
 						description: 'User added successfully.',
@@ -293,6 +301,14 @@ const swaggerDocument = {
 				tags: ['Groups'],
 				summary: 'Get Group by ID',
 				description: 'This route is used to get a particular group by its ID.',
+				parameters: [
+					{
+						name: 'groupId',
+						in: 'path',
+						required: true,
+						type: 'string',
+					},
+				],
 			},
 		},
 		'/groups/events/{groupId}': {
@@ -300,6 +316,22 @@ const swaggerDocument = {
 				tags: ['Groups'],
 				summary: 'Get Events in Group',
 				description: 'This route is used to get all events under a specific group.',
+				parameters: [
+					{
+						name: 'groupId',
+						in: 'path',
+						required: true,
+						type: 'string',
+					},
+				],
+				responses: {
+					200: {
+						description: 'Events retrieved successfully.',
+					},
+					404: {
+						description: 'No events found for this group.',
+					},
+				},
 			},
 		},
 	},


### PR DESCRIPTION
## Description

Retrieve all events under a group.

TICKET: https://linear.app/zuri-project-backend/issue/EVE-20/get-group-events

API DOCS: [https://wetindeysup-api.onrender.com/api-docs/#/Groups/get_groups_events__groupId_](https://wetindeysup-api.onrender.com/api-docs/#/Groups/get_groups_events__groupId_)

LIVE LINK: https://wetindeysup-api.onrender.com/api/groups/events/:groupId

## How Has This Been Tested?

Manual Testing: I manually tested the API endpoints to ensure it returns the expected outputs.


## Screenshots (if appropriate):
![image](https://github.com/hngx-org/Team-Events-Nodejs-Backend/assets/58990930/21cf4b74-378d-47c0-9c8e-8c8aee763e40)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)