### PR TITLE
EVE-22/Feat: Implement createComment and getComments

### DIFF
--- a/src/Controllers/comment.controller.ts
+++ b/src/Controllers/comment.controller.ts
@@ -1,9 +1,63 @@
-import { PrismaClient } from '@prisma/client'
-import { Request, Response } from 'express'
-const prisma = new PrismaClient()
+import { PrismaClient, User } from '@prisma/client';
+import { Request, Response } from 'express';
+import Joi from 'joi';
+const prisma = new PrismaClient();
 
-const createComment = (req: Request, res: Response) => {}
+const createComment = async (req: Request, res: Response) => {
+	try {
+		const userId = (req.user as User).id;
+		const eventId = req.params.eventId;
 
-const getComments = (req: Request, res: Response) => {}
+		const requestSchema = Joi.object({
+			comment: Joi.string().required(),
+		});
 
-export { createComment, getComments }
+		const { error } = requestSchema.validate(req.body);
+		if (error) return res.status(400).json({ error: error.details[0].message });
+
+		const { comment } = req.body;
+
+		const newComment = await prisma.comment.create({
+			data: {
+				event_id: eventId,
+				created_by: userId,
+				comment,
+			},
+		});
+
+		res.status(201).json({
+			statusCode: 201,
+			message: 'Comment created successfully',
+			data: newComment,
+		});
+	} catch (error) {
+		console.error('Error creating comment:', error);
+		res.status(500).json({ error: 'Error creating comment' });
+	}
+};
+
+const getComments = async (req: Request, res: Response) => {
+	const eventId = req.params.eventId;
+
+	try {
+		const comments = await prisma.comment.findMany({
+			where: {
+				event_id: eventId,
+			},
+		});
+
+		if (comments.length > 0) {
+			res.status(200).json({
+				statusCode: 200,
+				data: comments,
+			});
+		} else {
+			res.status(404).json({ error: 'No comments found for this event' });
+		}
+	} catch (error) {
+		console.error(error);
+		res.status(500).json({ error: 'An error occurred while fetching comments.' });
+	}
+};
+
+export { createComment, getComments };

--- a/src/Routes/comment.routes.ts
+++ b/src/Routes/comment.routes.ts
@@ -1,16 +1,18 @@
-import { Router } from 'express'
-import { createComment, getComments } from '../Controllers/comment.controller'
-const router = Router()
+import { Router } from 'express';
+import { createComment, getComments } from '../Controllers/comment.controller';
+import protect from '../middleware/auth.middleware';
+const router = Router();
 
-/*@POST /comment
+/*@POST /comments/:eventId
  * This route should take care of creating a comment
  * PROTECTED ROUTE
  */
-router.post('/', createComment)
+router.post('/:eventId', protect, createComment);
 
-/*@GET /comment/all/:eventId
+/*@GET /comments/:eventId
  * This route should take care of getting all comments under a particular event
  * PROTECTED ROUTE
  */
-router.get('/all/:eventId', getComments)
-export default router
+router.get('/:eventId', getComments);
+
+export default router;

--- a/src/Routes/index.ts
+++ b/src/Routes/index.ts
@@ -11,6 +11,6 @@ import comment from './comment.routes';
 router.use('/auth', auth);
 router.use('/events', event);
 router.use('/groups', group);
-router.use('/comment', comment);
+router.use('/comments', comment);
 
 export default router;

--- a/swagger.ts
+++ b/swagger.ts
@@ -1,27 +1,27 @@
 // Define the Swagger document in JavaScript format
 const swaggerDocument = {
-	swagger: '2.0',
+	openapi: '3.0.0',
 	info: {
 		title: 'Team Events API (NodeJs)',
 		version: '1.0.0',
-		description: 'https://wetindeysup-api.onrender.com/api-docs',
+		description: 'https://wetindeysup-api.onrender.com/api',
 	},
-	basePath: '/api',
-	// schemes: ['http'],
-	securityDefinitions: {
-		BearerAuth: {
-			type: 'apiKey',
-			name: 'Authorization',
-			in: 'header',
+	components: {
+		securitySchemes: {
+			bearerAuth: {
+				type: 'http',
+				scheme: 'bearer',
+				bearerFormat: 'JWT',
+			},
 		},
 	},
 	security: [
 		{
-			BearerAuth: [] as any[],
+			bearerAuth: [] as any,
 		},
 	],
 	paths: {
-		'/auth/google': {
+		'/api/auth/google': {
 			get: {
 				tags: ['Auth'],
 				summary: 'Authenticate with Google',
@@ -33,7 +33,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/auth/google/callback': {
+		'/api/auth/google/callback': {
 			get: {
 				tags: ['Auth'],
 				summary: 'Google OAuth Callback',
@@ -51,7 +51,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/auth/twitter': {
+		'/api/auth/twitter': {
 			post: {
 				tags: ['Auth'],
 				summary: 'Authenticate with Twitter',
@@ -63,7 +63,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/auth/twitter/callback': {
+		'/api/auth/twitter/callback': {
 			post: {
 				tags: ['Auth'],
 				summary: 'Twitter Authentication Callback',
@@ -81,7 +81,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/auth/logout': {
+		'/api/auth/logout': {
 			post: {
 				tags: ['Auth'],
 				summary: 'Logout',
@@ -93,27 +93,8 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/comment': {
-			post: {
-				tags: ['Comment'],
-				summary: 'Create Comment',
-				description: 'This route is used to create a comment.',
-				responses: {
-					201: {
-						description: 'Comment created successfully.',
-					},
-					500: {
-						description: 'Comment creation error.',
-					},
-				},
-			},
-			get: {
-				tags: ['Comment'],
-				summary: 'Get Comments',
-				description: 'This route is used to get comments.',
-			},
-		},
-		'/events': {
+
+		'/api/events': {
 			post: {
 				tags: ['Event'],
 				summary: 'Create Event',
@@ -141,7 +122,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/events/friends': {
+		'/api/events/friends': {
 			get: {
 				tags: ['Event'],
 				summary: 'Get Friend Events',
@@ -156,7 +137,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/events/search': {
+		'/api/events/search': {
 			get: {
 				tags: ['Event'],
 				summary: 'Search Events',
@@ -179,7 +160,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/events/info/{eventId}': {
+		'/api/events/info/{eventId}': {
 			get: {
 				tags: ['Event'],
 				summary: 'Get Event by ID',
@@ -202,7 +183,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/events/{eventId}': {
+		'/api/events/{eventId}': {
 			put: {
 				tags: ['Event'],
 				summary: 'Update Event',
@@ -246,7 +227,71 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/groups': {
+
+		'/api/comments/{eventId}': {
+			post: {
+				tags: ['Comment'],
+				summary: 'Create Comment',
+				description: 'This route is used to create a comment.',
+				parameters: [
+					{
+						name: 'eventId',
+						in: 'path',
+						required: true,
+						type: 'string',
+					},
+				],
+				requestBody: {
+					required: true,
+					content: {
+						'application/json': {
+							schema: {
+								type: 'object',
+								properties: {
+									comment: {
+										type: 'string',
+									},
+								},
+							},
+							example: {
+								comment: 'Nice. I will be there.',
+							},
+						},
+					},
+				},
+				responses: {
+					201: {
+						description: 'Comment created successfully.',
+					},
+					500: {
+						description: 'Error creating comment.',
+					},
+				},
+			},
+			get: {
+				tags: ['Comment'],
+				summary: 'Get Comments',
+				description: 'This route is used to get comments.',
+				parameters: [
+					{
+						name: 'eventId',
+						in: 'path',
+						required: true,
+						type: 'string',
+					},
+				],
+				responses: {
+					201: {
+						description: 'Comments retrieved successfully.',
+					},
+					404: {
+						description: 'No comments found for this event.',
+					},
+				},
+			},
+		},
+
+		'/api/groups': {
 			post: {
 				tags: ['Groups'],
 				summary: 'Create Group',
@@ -275,7 +320,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/groups/{groupId}/addUser': {
+		'/api/groups/{groupId}/addUser': {
 			post: {
 				tags: ['Groups'],
 				summary: 'Add user to group',
@@ -298,7 +343,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/groups/info/{groupId}': {
+		'/api/groups/info/{groupId}': {
 			get: {
 				tags: ['Groups'],
 				summary: 'Get Group by ID',
@@ -321,7 +366,7 @@ const swaggerDocument = {
 				},
 			},
 		},
-		'/groups/events/{groupId}': {
+		'/api/groups/events/{groupId}': {
 			get: {
 				tags: ['Groups'],
 				summary: 'Get Events in Group',


### PR DESCRIPTION
## Description

Create and retrieve comments under a particular event

TICKET: https://linear.app/zuri-project-backend/issue/EVE-22/create-and-get-comments

API DOCS: https://wetindeysup-api.onrender.com/api-docs/#/Comment

LIVE LINK: https://wetindeysup-api.onrender.com/api/comments/:eventId

## How Has This Been Tested?

Manual Testing: I manually tested the API endpoints to ensure it returns the expected outputs.


## Screenshots (if appropriate):



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)